### PR TITLE
refactor(Controllers): Déplacement du nom de l'endpoint en haut du controller

### DIFF
--- a/src/main/java/com/example/marmite/Controller/CategorieController.java
+++ b/src/main/java/com/example/marmite/Controller/CategorieController.java
@@ -17,28 +17,28 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/api")
+@RequestMapping("/api/categories")
 public class CategorieController {
     @Autowired
     private CategorieRepository categorieRepository;
 
-    @GetMapping("/categories")
+    @GetMapping("")
     public ResponseEntity<List<Categorie>> getAllCategories() {
         return ResponseEntity.ok((List<Categorie>) categorieRepository.findAll());
     }
 
-    @PostMapping("/categories")
+    @PostMapping("")
     public ResponseEntity<Categorie> createCategorie(@RequestBody Categorie categorie) {
         categorieRepository.save(categorie);
         return ResponseEntity.ok(categorie);
     }
 
-    @GetMapping("/categories/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<Categorie> getCategorieById(@PathVariable Long id) {
         return ResponseEntity.ok(categorieRepository.findById(id).orElse(null));
     }
 
-    @PutMapping("/categories/{id}")
+    @PutMapping("/{id}")
     public ResponseEntity<Categorie> updateCategorie(@PathVariable Long id, @RequestBody Categorie categorie) {
         Categorie categorieToUpdate = categorieRepository.findById(id).orElse(null);
         if (categorieToUpdate != null) {
@@ -50,7 +50,7 @@ public class CategorieController {
         return ResponseEntity.ok(categorieToUpdate);
     }
 
-    @DeleteMapping("/categories/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Categorie> deleteCategorie(@PathVariable Long id) {
         Categorie categorieToDelete = categorieRepository.findById(id).orElse(null);
         if (categorieToDelete != null) {

--- a/src/main/java/com/example/marmite/Controller/IngredientController.java
+++ b/src/main/java/com/example/marmite/Controller/IngredientController.java
@@ -17,28 +17,28 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/api")
+@RequestMapping("/api/ingredients")
 public class IngredientController {
     @Autowired
     private IngredientRepository ingredientRepository;
 
-    @GetMapping("/ingredients")
+    @GetMapping("")
     public ResponseEntity<List<Ingredient>> getAllIngredients() {
         return ResponseEntity.ok((List<Ingredient>) ingredientRepository.findAll());
     }
 
-    @PostMapping("/ingredients")
+    @PostMapping("")
     public ResponseEntity<Ingredient> createIngredient(@RequestBody Ingredient ingredient) {
         ingredientRepository.save(ingredient);
         return ResponseEntity.ok(ingredient);
     }
 
-    @GetMapping("/ingredients/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<Ingredient> getIngredientById(@PathVariable Long id) {
         return ResponseEntity.ok(ingredientRepository.findById(id).orElse(null));
     }
 
-    @PutMapping("/ingredients/{id}")
+    @PutMapping("/{id}")
     public ResponseEntity<Ingredient> updateIngredient(@PathVariable Long id, @RequestBody Ingredient ingredient) {
         Ingredient ingredientToUpdate = ingredientRepository.findById(id).orElse(null);
         if (ingredientToUpdate != null) {
@@ -50,7 +50,7 @@ public class IngredientController {
         return ResponseEntity.ok(ingredientToUpdate);
     }
 
-    @DeleteMapping("/ingredients/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Ingredient> deleteIngredient(@PathVariable Long id) {
         Ingredient ingredientToDelete = ingredientRepository.findById(id).orElse(null);
         if (ingredientToDelete != null) {


### PR DESCRIPTION
Déplacer en haut du controller permet d'avoir le nom du endpoint partagé et c'est plus consistent, et ça petmet de ne pas se répéter